### PR TITLE
update geotools osgeo repo change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
 		<repository>
 			<id>osgeo</id>
 			<name>Open Source Geospatial Foundation Repository</name>
-			<url>http://download.osgeo.org/webdav/geotools/</url>
+			<!--<url>http://download.osgeo.org/webdav/geotools/</url>-->
+			<url>https://repo.osgeo.org/repository/release/</url>
 		</repository>
  		<repository>
 			<!-- For MATSim snapshots: -->


### PR DESCRIPTION
Fix maven build error due to the geotools repo change.
https://docs.geotools.org/latest/userguide/tutorial/quickstart/maven.html